### PR TITLE
[catch2] Use json to save temporary information when testing

### DIFF
--- a/recipes/catch2/2.x.x/test_package/conanfile.py
+++ b/recipes/catch2/2.x.x/test_package/conanfile.py
@@ -2,19 +2,20 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain
 from conan.tools.build import can_run
 from conan.tools.cmake import cmake_layout
+from conan.tools.files import save, load
 import os
-import yaml
+import json
+
 
 class TestPackageConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeDeps", "VirtualRunEnv"
     test_type = "explicit"
 
-    _tests_todo = []
 
     @property
     def _todos_filename(self):
-        return os.path.join(self.recipe_folder, "test_output", self.folders.generators, "catch2_test_to_do.yml")
+        return os.path.join(self.build_folder, "catch2_test_to_do.yml")
 
     def requirements(self):
         self.requires(self.tested_reference_str)
@@ -28,14 +29,12 @@ class TestPackageConan(ConanFile):
         tc.generate()
 
         # note: this is required as self.dependencies is not available in test()
-        self._tests_todo.append("test_package")
+        tests_todo = ["test_package"]
         if catch_opts.with_main:
-            self._tests_todo.append("standalone")
+            tests_todo.append("standalone")
         if not catch_opts.with_prefix and catch_opts.with_main and catch_opts.with_benchmark:
-            self._tests_todo.append("benchmark")
-
-        with open(self._todos_filename, "w", encoding="utf-8") as file:
-            yaml.dump(self._tests_todo, file)
+            tests_todo.append("benchmark")
+        save(self, self._todos_filename, json.dumps(tests_todo))
 
     def layout(self):
         cmake_layout(self)
@@ -46,8 +45,7 @@ class TestPackageConan(ConanFile):
         cmake.build()
 
     def test(self):
-        with open(self._todos_filename, "r", encoding="utf-8") as file:
-            self._tests_todo = yaml.safe_load(file)
+        tests_todo = json.loads(load(self, self._todos_filename))
         if can_run(self):
-            for test_name in self._tests_todo:
+            for test_name in tests_todo:
                 self.run(os.path.join(self.cpp.build.bindirs[0], test_name), env="conanrun")


### PR DESCRIPTION
When running locally, on Docker with GCC5, I had the follow error:

```
ERROR: catch2/2.13.7 (test package): Error in generate() method, line 37
	with open(self._todos_filename, "w", encoding="utf-8") as file:
	FileNotFoundError: [Errno 2] No such file or directory: '/home/conan/project/test_package/test_output/build/generators/catch2_test_to_do.yml'
```

It occurred because the `todo_filename`'s directory does not exist when running generate, so we would need to run a `mkdir` first.

On this PR I updated few things:

- self._todo_filename is not needed, as the variable is not re-used indeed. It's lost between `conan test` execution
- Python does not offer native YAML support, instead, we got a ride from Conan dependencies, but it's too risk. On the other hand, JSON is supported by python itself and we run no risks.
- Using Conan tools to save/load not only simplifies some lines, but also may consider permission tricks on Windows for instance.
- Move temporary file to build folder, as it can be removed after building.


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
